### PR TITLE
Bypass starlette.Response objects.

### DIFF
--- a/src/simpleindex/__main__.py
+++ b/src/simpleindex/__main__.py
@@ -4,7 +4,6 @@ import typing
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import Response
 from starlette.routing import Route
 from uvicorn import run as run_uvicorn
 
@@ -13,24 +12,12 @@ from . import configs, routes
 
 def _build_routes(key: str, route: routes.Route) -> typing.List[Route]:
     async def page(request: Request):
-        response = await route.get_page(request.path_params)
-        return Response(
-            content=response.content,
-            status_code=response.status_code,
-            media_type=response.media_type,
-            headers=response.headers,
-        )
+        return await route.get_page(request.path_params)
 
     async def dist(request: Request):
         params = request.path_params
         filename = params.pop(filename_param)
-        response = await route.get_file(params, filename)
-        return Response(
-            content=response.content,
-            status_code=response.status_code,
-            media_type=response.media_type,
-            headers=response.headers,
-        )
+        return await route.get_file(params, filename)
 
     filename_param = "__simpleindex_match_filename__"
     return [

--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -6,14 +6,7 @@ import pathlib
 import typing
 
 import packaging.utils
-
-
-@dataclasses.dataclass()
-class Response:
-    content: typing.Union[bytes, str] = b""
-    status_code: int = 200
-    media_type: str = "text/plain"
-    headers: typing.Optional[typing.Mapping[str, str]] = None
+from starlette.responses import Response
 
 
 Params = typing.Mapping[str, typing.Any]


### PR DESCRIPTION
In this design, the `Route.get_page` and `Route.get_file` functions return `starlette` object directly, and the framework bypasses these objects to starlette. This give large flexilibilty which `starlette.Response` objects are used in the custom routes, but it bind `simpleindex` to `starlette`