### PR TITLE
Add StreamingResponse class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
 
 [tool.flit.metadata.requires-extra]
 test = [
-    "mousebender",
+    "mousebender==v2.0.0",
     "pytest",
     "pytest-asyncio",
     "pytest-httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = [
 
 [tool.flit.metadata.requires-extra]
 test = [
-    "mousebender==v2.0.0",
+    "mousebender",
     "pytest",
     "pytest-asyncio",
     "pytest-httpx",

--- a/src/simpleindex/__main__.py
+++ b/src/simpleindex/__main__.py
@@ -19,7 +19,7 @@ def _build_routes(key: str, route: routes.Route) -> typing.List[Route]:
         params = request.path_params
         filename = params.pop(filename_param)
         response = await route.get_file(params, filename)
-        response.to_http_response()
+        return response.to_http_response()
 
     filename_param = "__simpleindex_match_filename__"
     return [

--- a/src/simpleindex/__main__.py
+++ b/src/simpleindex/__main__.py
@@ -42,12 +42,7 @@ def _build_routes(key: str, route: routes.Route) -> typing.List[Route]:
         params = request.path_params
         filename = params.pop(filename_param)
         response = await route.get_file(params, filename)
-        return Response(
-            content=response.content,
-            status_code=response.status_code,
-            media_type=response.media_type,
-            headers=response.headers,
-        )
+        return _to_http_response(response)
 
     filename_param = "__simpleindex_match_filename__"
     return [

--- a/src/simpleindex/__main__.py
+++ b/src/simpleindex/__main__.py
@@ -4,45 +4,22 @@ import typing
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import Response, StreamingResponse
 from starlette.routing import Route
 from uvicorn import run as run_uvicorn
 
 from . import configs, routes
 
 
-def _to_http_response(
-    response: typing.Union[routes.Response, routes.StreamingResponse]
-):
-    # The order is crutial due the inheritance between *Response classes
-    if isinstance(response, routes.StreamingResponse):
-        return StreamingResponse(
-            content=response.content,
-            status_code=response.status_code,
-            media_type=response.media_type,
-            headers=response.headers,
-        )
-    elif isinstance(response, routes.Response):
-        return Response(
-            content=response.content,
-            status_code=response.status_code,
-            media_type=response.media_type,
-            headers=response.headers,
-        )
-    else:
-        raise TypeError(f"Invalid type {type(response)}")
-
-
 def _build_routes(key: str, route: routes.Route) -> typing.List[Route]:
     async def page(request: Request):
         response = await route.get_page(request.path_params)
-        return _to_http_response(response)
+        return response.to_http_response()
 
     async def dist(request: Request):
         params = request.path_params
         filename = params.pop(filename_param)
         response = await route.get_file(params, filename)
-        return _to_http_response(response)
+        response.to_http_response()
 
     filename_param = "__simpleindex_match_filename__"
     return [

--- a/src/simpleindex/configs.py
+++ b/src/simpleindex/configs.py
@@ -34,10 +34,7 @@ class ConfigurationKeyNotFound(ValueError):
 @functools.lru_cache(maxsize=None)
 def _get_route_source_choices() -> typing.Dict[str, typing.Type[Route]]:
     entry_points = importlib.metadata.entry_points()
-    return {
-        ep.name: ep.load()
-        for ep in entry_points.get("simpleindex.routes", [])
-    }
+    return {ep.name: ep.load() for ep in entry_points.get("simpleindex.routes", [])}
 
 
 def _validate_route_source(v: typing.Union[str, _RouteSource]) -> _RouteSource:

--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -6,12 +6,15 @@ import pathlib
 import typing
 
 import packaging.utils
+from starlette.responses import Response as StarletteResponse
+from starlette.responses import StreamingResponse as StarletteStreamingResponse
 
 Content = typing.Union[bytes, str]
 SyncContentStream = typing.Iterable[Content]
 AsyncContentStream = typing.AsyncIterable[Content]
 ContentStream = typing.Union[AsyncContentStream, SyncContentStream]
 Params = typing.Mapping[str, typing.Any]
+Headers = typing.Mapping[str, str]
 
 
 @dataclasses.dataclass()
@@ -19,12 +22,24 @@ class Response:
     content: Content = b""
     status_code: int = 200
     media_type: str = "text/plain"
-    headers: typing.Optional[typing.Mapping[str, str]] = None
+    headers: typing.Optional[Headers] = None
+
+    _http_response_class = StarletteResponse
+
+    def to_http_response(self) -> StarletteResponse:
+        return self._http_response_class(
+            content=self.content,
+            status_code=self.status_code,
+            media_type=self.media_type,
+            headers=self.headers,
+        )
 
 
 @dataclasses.dataclass()
 class StreamingResponse(Response):
     content: ContentStream = ()
+    
+    _http_response_class = StarletteStreamingResponse
 
 
 @dataclasses.dataclass()

--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -24,7 +24,7 @@ class Response:
 
 @dataclasses.dataclass()
 class StreamingResponse(Response):
-    content: ContentStream = tuple()
+    content: ContentStream = ()
 
 
 @dataclasses.dataclass()

--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -24,7 +24,7 @@ class Response:
 
 @dataclasses.dataclass()
 class StreamingResponse(Response):
-    content: ContentStream = []
+    content: ContentStream = tuple()
 
 
 @dataclasses.dataclass()

--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -7,16 +7,24 @@ import typing
 
 import packaging.utils
 
+Content = typing.Union[bytes, str]
+SyncContentStream = typing.Iterable[Content]
+AsyncContentStream = typing.AsyncIterable[Content]
+ContentStream = typing.Union[AsyncContentStream, SyncContentStream]
+Params = typing.Mapping[str, typing.Any]
+
 
 @dataclasses.dataclass()
 class Response:
-    content: typing.Union[bytes, str] = b""
+    content: Content = b""
     status_code: int = 200
     media_type: str = "text/plain"
     headers: typing.Optional[typing.Mapping[str, str]] = None
 
 
-Params = typing.Mapping[str, typing.Any]
+@dataclasses.dataclass()
+class StreamingResponse(Response):
+    content: ContentStream = []
 
 
 @dataclasses.dataclass()

--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -38,7 +38,7 @@ class Response:
 @dataclasses.dataclass()
 class StreamingResponse(Response):
     content: ContentStream = ()
-    
+
     _http_response_class = StarletteStreamingResponse
 
 

--- a/tests/test_build_routes.py
+++ b/tests/test_build_routes.py
@@ -2,7 +2,6 @@ import pytest
 from starlette.responses import Response as StarletteResponse
 from starlette.responses import StreamingResponse as StarletteStreamingResponse
 
-from simpleindex.__main__ import _to_http_response
 from simpleindex.routes import Response, StreamingResponse
 
 
@@ -17,7 +16,7 @@ def test_response_conversion():
     response = Response(
         content=content, status_code=status_code, media_type=media_type, headers=headers
     )
-    starlette_response = _to_http_response(response)
+    starlette_response = response.to_http_response()
 
     assert isinstance(starlette_response, StarletteResponse)
 
@@ -50,7 +49,7 @@ async def test_streaming_response_conversion():
         media_type=media_type,
         headers=headers,
     )
-    starlette_response = _to_http_response(response)
+    starlette_response = response.to_http_response()
 
     assert isinstance(starlette_response, StarletteStreamingResponse)
 

--- a/tests/test_build_routes.py
+++ b/tests/test_build_routes.py
@@ -1,0 +1,63 @@
+import pytest
+from starlette.responses import Response as StarletteResponse
+from starlette.responses import StreamingResponse as StarletteStreamingResponse
+
+from simpleindex.__main__ import _to_http_response
+from simpleindex.routes import Response, StreamingResponse
+
+
+def test_response_conversion():
+    content = "{ value: 42 }"
+    status_code = 401
+    media_type = "application/json"
+    header_key = "Header Key"
+    header_value = "header value"
+    headers = {header_key: header_value}
+
+    response = Response(
+        content=content, status_code=status_code, media_type=media_type, headers=headers
+    )
+    starlette_response = _to_http_response(response)
+
+    assert isinstance(starlette_response, StarletteResponse)
+
+    assert starlette_response.body.decode(starlette_response.charset) == content
+    assert starlette_response.status_code == status_code
+    assert starlette_response.media_type == media_type
+    assert (
+        header_key in starlette_response.headers
+        and starlette_response.headers[header_key] == header_value
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_conversion():
+    content_text = "{ value: 42 }"
+
+    async def content():
+        for c in content_text:
+            yield c
+
+    status_code = 401
+    media_type = "application/json"
+    header_key = "Header Key"
+    header_value = "header value"
+    headers = {header_key: header_value}
+
+    response = StreamingResponse(
+        content=content(),
+        status_code=status_code,
+        media_type=media_type,
+        headers=headers,
+    )
+    starlette_response = _to_http_response(response)
+
+    assert isinstance(starlette_response, StarletteStreamingResponse)
+
+    assert "".join([v async for v in starlette_response.body_iterator]) == content_text
+    assert starlette_response.status_code == status_code
+    assert starlette_response.media_type == media_type
+    assert (
+        header_key in starlette_response.headers
+        and starlette_response.headers[header_key] == header_value
+    )

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,13 +3,13 @@ import pathlib
 
 import pytest
 
-from simpleindex.configs import _Route, parse
+from simpleindex.configs import Configuration, _Route
 from simpleindex.routes import HTTPRoute, PathRoute
 
 
 def test_configuration_parse(tmp_path):
     with importlib.resources.path("examples", "annotated.toml") as path:
-        conf = parse(path)
+        conf = Configuration.parse(path, prefix=None)
     assert conf.server == {"host": "127.0.0.1", "port": 8000}
     assert conf.routes == {
         "my-first-package": _Route(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -72,7 +72,10 @@ async def test_path_route_invalid_files(tmp_path):
 
     links = mousebender.simple.from_project_details_html(resp.content, "")
     assert [file["filename"] for file in links["files"]] == expected_project_files
-    assert [file["url"] for file in links["files"]] == [f"./{n}" for n in expected_project_files]
+    assert [file["url"] for file in links["files"]] == [
+        f"./{n}" for n in expected_project_files
+    ]
+
 
 @pytest.mark.asyncio
 async def test_http_route():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,7 +23,7 @@ async def test_path_route_directory(tmp_path):
     resp = await route.get_page({"project": "my-package"})
     assert resp.status_code == 200
 
-    links = mousebender.simple.parse_archive_links(resp.text)
+    links = mousebender.simple.parse_archive_links(resp.content)
     assert [link.filename for link in links] == project_files
     assert [link.url for link in links] == [f"./{n}" for n in project_files]
 
@@ -37,27 +37,22 @@ async def test_path_route_file(tmp_path):
     route = PathRoute(root=tmp_path, to="{project}.html")
     resp = await route.get_page({"project": "project"})
     assert resp.status_code == 200
-    assert resp.text == "<body>test content</body>"
+    assert resp.content.decode() == "<body>test content</body>"
 
 
 @pytest.mark.asyncio
 async def test_path_route_invalid(tmp_path):
-    """404 is returned if the path does not point to a file or directory.
-    """
+    """404 is returned if the path does not point to a file or directory."""
     route = PathRoute(root=tmp_path, to="does-not-exist")
     resp = await route.get_page({})
     assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_http_route(httpx_mock):
-    httpx_mock.add_response(
-        url="http://example.com/simple/package/",
-        data=b"<body>test content</body>",
-    )
+async def test_http_route():
     route = HTTPRoute(
         root=pathlib.Path("does-not-matter"),
         to="http://example.com/simple/{project}/",
     )
     resp = await route.get_page({"project": "package"})
-    assert resp.text == "<body>test content</body>"
+    assert resp.status_code == 302

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -23,9 +23,9 @@ async def test_path_route_directory(tmp_path):
     resp = await route.get_page({"project": "my-package"})
     assert resp.status_code == 200
 
-    links = mousebender.simple.parse_archive_links(resp.content)
-    assert [link.filename for link in links] == project_files
-    assert [link.url for link in links] == [f"./{n}" for n in project_files]
+    links = mousebender.simple.from_project_details_html(resp.content, "")
+    assert [file["filename"] for file in links["files"]] == project_files
+    assert [file["url"] for file in links["files"]] == [f"./{n}" for n in project_files]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR introduces the new `StreamingResponse` class to enable streaming HTTP response from custom routes.
Additionally, this PR fixes the existing tests, and introduces a basic test for the type conversion.