### PR TITLE
Fixes #9: Handle InvalidVersion errors when validating filenames

### DIFF
--- a/src/simpleindex/routes.py
+++ b/src/simpleindex/routes.py
@@ -45,10 +45,16 @@ _HTML = """
 
 
 def _is_valid_dist_filename(filename: str) -> bool:
-    with contextlib.suppress(packaging.utils.InvalidWheelFilename):
+    with contextlib.suppress(
+        packaging.utils.InvalidWheelFilename,
+        packaging.utils.InvalidVersion,
+    ):
         packaging.utils.parse_wheel_filename(filename)
         return True
-    with contextlib.suppress(packaging.utils.InvalidSdistFilename):
+    with contextlib.suppress(
+        packaging.utils.InvalidSdistFilename,
+        packaging.utils.InvalidVersion,
+    ):
         packaging.utils.parse_sdist_filename(filename)
         return True
     return False

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -71,9 +71,9 @@ async def test_path_route_invalid_files(tmp_path):
     resp = await route.get_page({"project": "my-package"})
     assert resp.status_code == 200
 
-    links = mousebender.simple.parse_archive_links(resp.content)
-    assert [link.filename for link in links] == expected_project_files
-    assert [link.url for link in links] == [f"./{n}" for n in expected_project_files]
+    links = mousebender.simple.from_project_details_html(resp.content, "")
+    assert [file["filename"] for file in links["files"]] == expected_project_files
+    assert [file["url"] for file in links["files"]] == [f"./{n}" for n in expected_project_files]
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -76,7 +76,6 @@ async def test_path_route_invalid_files(tmp_path):
     assert [link.url for link in links] == [f"./{n}" for n in expected_project_files]
 
 
-
 @pytest.mark.asyncio
 async def test_http_route(httpx_mock):
     httpx_mock.add_response(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -50,6 +50,34 @@ async def test_path_route_invalid(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_path_route_invalid_files(tmp_path):
+    """An HTML document for a local directory ignores invalid files."""
+    directory = tmp_path.joinpath("my-package")
+    directory.mkdir()
+
+    expected_project_files = [
+        "my-package-1.0.tar.gz",
+        "my_package-1.0-py2.py3-none-any.whl",
+    ]
+    project_files = [
+        *expected_project_files,
+        "my-package-invalid_version.tar.gz",
+        "my_package-..01-py2.py3-none-any.whl",
+    ]
+    for name in project_files:
+        directory.joinpath(name).touch()
+
+    route = PathRoute(root=tmp_path, to="{project}")
+    resp = await route.get_page({"project": "my-package"})
+    assert resp.status_code == 200
+
+    links = mousebender.simple.parse_archive_links(resp.content)
+    assert [link.filename for link in links] == expected_project_files
+    assert [link.url for link in links] == [f"./{n}" for n in expected_project_files]
+
+
+
+@pytest.mark.asyncio
 async def test_http_route(httpx_mock):
     httpx_mock.add_response(
         url="http://example.com/simple/package/",


### PR DESCRIPTION
Worth noting that the new test passes with mousebender==2.0, but everything fails with the newer version. I believe another PR has fixes for tests right now, so I haven't gone through them all here.