### PR TITLE
Expose run function to execute simpleindex from another Python module.

### DIFF
--- a/src/simpleindex/__init__.py
+++ b/src/simpleindex/__init__.py
@@ -2,3 +2,5 @@
 """
 
 __version__ = "0.4.0"
+
+from .__main__ import run

--- a/src/simpleindex/__init__.py
+++ b/src/simpleindex/__init__.py
@@ -1,6 +1,10 @@
-"""PEP 503 Simple Repository index by declaring routing rules.
-"""
+"""PEP 503 Simple Repository index by declaring routing rules."""
 
-__version__ = "0.4.0"
+__all__ = [
+    "__version__",
+    "run",
+]
 
 from .__main__ import run
+
+__version__ = "0.4.0"

--- a/src/simpleindex/__main__.py
+++ b/src/simpleindex/__main__.py
@@ -1,5 +1,6 @@
 import argparse
 import itertools
+import sys
 import typing
 
 from starlette.applications import Starlette
@@ -39,14 +40,15 @@ def _build_routes(key: str, route: routes.Route) -> typing.List[Route]:
     ]
 
 
-def main():
+def run(args: typing.List[str]):
+    print(args)
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "config",
         type=configs.Configuration.parse_arg,
         help="Path to configuration file",
     )
-    ns = parser.parse_args()
+    ns = parser.parse_args(args)
 
     config_path, configuration = ns.config
 
@@ -61,4 +63,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run(sys.argv[1:])

--- a/src/simpleindex/__main__.py
+++ b/src/simpleindex/__main__.py
@@ -1,6 +1,5 @@
 import argparse
 import itertools
-import sys
 import typing
 
 from starlette.applications import Starlette
@@ -40,8 +39,12 @@ def _build_routes(key: str, route: routes.Route) -> typing.List[Route]:
     ]
 
 
-def run(args: typing.List[str]):
-    print(args)
+def run(args: typing.Optional[typing.List[str]]) -> None:
+    """Run the index server.
+
+    :param args: CLI arguments to pass to the argument parser. If ``None`` is
+        passed, ``sys.argv[1:]`` is used (the default argparse behavior).
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "config",
@@ -63,4 +66,4 @@ def run(args: typing.List[str]):
 
 
 if __name__ == "__main__":
-    run(sys.argv[1:])
+    run(None)


### PR DESCRIPTION
This simple change enables embedding simpleindex into another Python module:

```python
from simpleindex import run
run(["/path/to/config.toml"])
```

Close #11.