### PR TITLE
Handle importlib.metadata.entry_points API change in python 3.12

### DIFF
--- a/src/simpleindex/configs.py
+++ b/src/simpleindex/configs.py
@@ -33,8 +33,10 @@ class ConfigurationKeyNotFound(ValueError):
 
 @functools.lru_cache(maxsize=None)
 def _get_route_source_choices() -> typing.Dict[str, typing.Type[Route]]:
-    entry_points = importlib.metadata.entry_points()
-    return {ep.name: ep.load() for ep in entry_points.get("simpleindex.routes", [])}
+    eps = importlib.metadata.entry_points()
+    group = "simpleindex.routes"
+    entry_points = eps.get(group, []) if isinstance(eps, dict) else eps.select(group=group)
+    return {ep.name: ep.load() for ep in entry_points}
 
 
 def _validate_route_source(


### PR DESCRIPTION
In python 3.12, `importlib.metadata.entry_points()` does not return a dict but a `EntryPoints` object which doesn't have dict-like interface. So running `simpleindex` in python 3.12 fails with exception:
```
AttributeError: 'EntryPoints' object has no attribute 'get'
```

Since the use-case here is simple, it can be handled by a simple `isinstance` check. Use the dict interface if a dict is returned otherwise use the "selectable" interface. It is not possible to use the new “selectable” interface before 3.10 without using additional backport dependencies.