### PR TITLE
Use select() API for >=3.10.

### DIFF
--- a/src/simpleindex/__init__.py
+++ b/src/simpleindex/__init__.py
@@ -7,7 +7,7 @@ __all__ = [
     "run",
 ]
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 
 def run(args: typing.Optional[typing.List[str]] = None) -> None:

--- a/src/simpleindex/configs.py
+++ b/src/simpleindex/configs.py
@@ -4,6 +4,7 @@ import dataclasses
 import functools
 import importlib.metadata
 import pathlib
+import sys
 import typing
 
 import pydantic
@@ -34,7 +35,10 @@ class ConfigurationKeyNotFound(ValueError):
 @functools.lru_cache(maxsize=None)
 def _get_route_source_choices() -> typing.Dict[str, typing.Type[Route]]:
     entry_points = importlib.metadata.entry_points()
-    return {ep.name: ep.load() for ep in entry_points.get("simpleindex.routes", [])}
+    if sys.version_info < (3, 10):
+        return {ep.name: ep.load() for ep in entry_points.get("simpleindex.routes", [])}
+    else:
+        return {ep.name: ep.load() for ep in entry_points.select(group="simpleindex.routes")}
 
 
 def _validate_route_source(

--- a/src/simpleindex/configs.py
+++ b/src/simpleindex/configs.py
@@ -35,10 +35,13 @@ class ConfigurationKeyNotFound(ValueError):
 @functools.lru_cache(maxsize=None)
 def _get_route_source_choices() -> typing.Dict[str, typing.Type[Route]]:
     entry_points = importlib.metadata.entry_points()
-    if sys.version_info < (3, 10):
-        return {ep.name: ep.load() for ep in entry_points.get("simpleindex.routes", [])}
+    try:
+        select = entry_points.select
+    except AttributeError:
+        routes = entry_points.get("simpleindex.routes", [])
     else:
-        return {ep.name: ep.load() for ep in entry_points.select(group="simpleindex.routes")}
+        routes = select(group="simpleindex.routes")
+    return {ep.name: ep.load() for ep in routes}
 
 
 def _validate_route_source(


### PR DESCRIPTION
Python 3.10 introduced a new `select()` API for `importlib.metadata.EntryPoints`, and Python 3.12 has removed the previous `get()` API. Hence, the current implementation breaks in Python 3.12. This PR fixes this issue in a backwards compatible way.